### PR TITLE
Permit use of action in all other repositories

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
 
           case $(uname -s) in
             MINGW64_NT?*)
-              pwsh ${{ github.action_path }}/util/install.ps1
+              pwsh "${{ github.action_path }}/util/install.ps1"
               ztcli="/c/Program Files (x86)/ZeroTier/One/zerotier-cli.bat"
               member_id=$("${ztcli}" info | awk '{ print $3 }')
               ;;

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
   using: 'composite'
   steps:
     - name: zerotier
-      uses: ./util/post
+      uses: zerotier/github-action/util/post@main
       with:
         main: |
           set -euo pipefail

--- a/action.yml
+++ b/action.yml
@@ -33,12 +33,12 @@ runs:
 
           case $(uname -s) in
             MINGW64_NT?*)
-              pwsh ./util/install.ps1
+              pwsh ${{ github.action_path }}/util/install.ps1
               ztcli="/c/Program Files (x86)/ZeroTier/One/zerotier-cli.bat"
               member_id=$("${ztcli}" info | awk '{ print $3 }')
               ;;
             *)
-              . ./util/install.sh &>/dev/null
+              . ${{ github.action_path }}/util/install.sh &>/dev/null
               member_id=$(sudo zerotier-cli info | awk '{ print $3 }')
             ;;
           esac


### PR DESCRIPTION
Attempting to use this action in any repository besides `zerotier/github-action` will show this error, even when using the example provided in the action documentation.
```
Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/REPO_NAME/REPO_NAME/util/post'. Did you forget to run actions/checkout before running your local action?
```

Upon inspection of this action's `action.yml`, the path `./` is used multiple times. In the context of a workflow which uses this action as a step, this means the active working directory, commonly the files of the repository where this action is being used, *not* the files of this action. This leads to a weird case where the action attempts to look for `util/post`, which only ever exists in this repo, and not in any other. A live example of this can be seen with the "test" jobs of [this run](https://github.com/ChlodAlejandro/github-action/actions/runs/3765753731/jobs/6401550805) (workflow file [here](https://github.com/ChlodAlejandro/github-action/actions/runs/3765753731/workflow) to confirm that this repo is being used).

This PR does two things: apply a fix (detailed below) so that this action can be used as soon as possible (it is currently unusable, both as `main` or `v1`), and remove all uses of `./` in the action.yml file. Extended tests for this PR (which includes an external use test) can be found [here](https://github.com/ChlodAlejandro/github-action/actions/runs/3765797771).

The fix here is to access `util/post` as a subfolder of the `zerotier/github-action` repository. This, however, locks `action.yml` to always use the `main` (latest) version of `util/post`. This is because `${{ github.action_path }}` (which provides the path to this action's files when being used in a workflow) cannot be used on [`uses`](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsuses), which does not take expressions. As long as `util/post` remains backwards-compatible with all released versions of this action, this shouldn't be a problem, but is something that needs to be noted.