### PR TITLE
Add external use tests to `build.yml`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,25 @@ jobs:
             let count=count-1
           done
           echo "ping success"
+  test:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: zerotier
+        uses: zerotier/github-action@main
+        with:
+          network_id: ${{ secrets.ZEROTIER_NETWORK_ID }}
+          auth_token: ${{ secrets.ZEROTIER_CENTRAL_TOKEN }}
+          
+      - name: ping host
+        shell: bash
+        run: |
+          count=10
+          while ! ping -c 1 ${{ secrets.ZEROTIER_HOST_IP }} ; do
+            echo "waiting..." ;
+            sleep 1 ;
+            let count=count-1
+          done
+          echo "ping success"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
             let count=count-1
           done
           echo "ping success"
+
   test:
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
+    if: github.ref_name === "main"
     steps:
       - name: zerotier
         uses: zerotier/github-action@main


### PR DESCRIPTION
`build.yml` currently does not test if this action can be used in other repositories. This pull request adds that check to avoid releasing faulty versions.

The added `test` job runs with principles: we assume that we know nothing about the contents of the current directory, and we use always use the main branch. The former ensures that the action will run on any repo, and is achieved by checking no repository out (thus, the working directory is blank). The latter ensures that the main branch is always working, since a working main branch means that tags made from the main branch will also work. For this reason, the `test` job will only run on pushes to the main branch. 

If #4 is not merged, merging this PR will automatically cause failing workflows, as `v1` and `main` (as of making this PR) are unusable in external repositories (see #4 for more info).