### PR TITLE
Update action.yml with missing application type header and loop

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
           esac
 
           echo "⏁  Authorizing Runner to ZeroTier network"
-          curl -s -X POST -H "Authorization: token ${{ inputs.auth_token }}" -d '{"config":{"authorized":true}}' "${{ inputs.api_url }}/network/${{ inputs.network_id }}/member/${member_id}"
+          while ! curl -s -X POST -H "Authorization: token ${{ inputs.auth_token }}" -H "Content-Type: application/json" -d '{"config":{"authorized":true}}' "${{ inputs.api_url }}/network/${{ inputs.network_id }}/member/${member_id}" | grep '"authorized":true' ; do sleep 2 ; done
 
           echo "⏁  Joining ZeroTier Network ID: ${{ inputs.network_id }}"
           case $(uname -s) in


### PR DESCRIPTION
In some scenarios I found that when application type header is missing, the API will not accept the request. This did fix the issue for my cases.

- Adding application type header for json typing
- Implementing while loop until authorization completes