### PR TITLE
updating node version and checkout action version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout
-        uses: actions/checkout@v3.2.0
+        uses: actions/checkout@v4.0.0
 
       - name: zerotier
         uses: ./

--- a/util/post/action.yml
+++ b/util/post/action.yml
@@ -37,6 +37,6 @@ inputs:
     default: POST
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'
   post: 'main.js'


### PR DESCRIPTION
Node 16 is now deprecated for github actions