### PR TITLE
Fix bug with zerotier uses defnition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout
-        uses: actions/checkout@v3.2.0
+        uses: actions/checkout@v4.0.0
 
       - name: zerotier
         uses: ./

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
   using: 'composite'
   steps:
     - name: zerotier
-      uses: zerotier/github-action/util/post@main
+      uses: ./util/post
       with:
         main: |
           set -euo pipefail

--- a/util/post/action.yml
+++ b/util/post/action.yml
@@ -37,6 +37,6 @@ inputs:
     default: POST
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'
   post: 'main.js'


### PR DESCRIPTION
This is a subtle bug zerotier/github-action/util/post@main points to the current head of main branch
If you where to updated ./util/post action.yml or main.sj it wouldn't be tested until the code was in main
