### PR TITLE
Add tags and capabilities to action definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,18 @@ The ZeroTier Github Action allows users to easily integrate
 ZeroTier into their CI/CD workflows by temporarily joining and
 authorizing runners onto private ZeroTier networks.
 
+Optional tags and capabilities can be specified depending on the
+configuration of your flow rules. The tags and capabilities
+must be already defined on ZeroTier Central.
+
 ```yaml
 - name: ZeroTier
   uses: zerotier/github-action@v1.0.1
   with:
     network_id: ${{ secrets.ZEROTIER_NETWORK_ID }}
     auth_token: ${{ secrets.ZEROTIER_CENTRAL_TOKEN }}
+    tags: 1000=8 2000=0
+    capabilities: 10 20
 ```
 
 `ZEROTIER_CENTRAL_TOKEN` can be provisioned from `Account` section in the [ZeroTier Central](https://my.zerotier.com) admin panel.
@@ -33,7 +39,8 @@ It then uses the supplied `auth_token` to authorize the runner onto the network.
   with:
     network_id: ${{ secrets.ZEROTIER_NETWORK_ID }}
     auth_token: ${{ secrets.ZEROTIER_CENTRAL_TOKEN }}
-    
+    tags: 1000=8 2000=0
+    capabilities: 10 20
 - name: ping host
   shell: bash
   run: |

--- a/action.yml
+++ b/action.yml
@@ -18,16 +18,30 @@ inputs:
     description: "ZeroTier Central API URL"
     required: false
     default: "https://my.zerotier.com/api/v1"
+  tags:
+    description: >
+      When provided, set tags for the network member (space-separated list of numeric "key=value" pairs).
+      The tags must be already defined on ZeroTier Central.
+    required: false
+    default: ""
+  capabilities:
+    description: >
+      When provided, set capabilities for the network member (space-separated numeric list).
+      The capabilities must be already defined on ZeroTier Central.
+    required: false
+    default: ""
 
 runs:
   using: "composite"
   steps:
     - name: zerotier
-      uses: zerotier/github-action/util/post@main
+      uses: zerotier/github-action/util/post@add-tags-and-capabilities
       env:
         API_URL: ${{ inputs.api_url }}
         AUTH_TOKEN: ${{ inputs.auth_token }}
         NETWORK_ID: ${{ inputs.network_id }}
+        TAGS: ${{ inputs.tags }}
+        CAPABILITIES: ${{ inputs.capabilities }}
       with:
         main: $GITHUB_ACTION_PATH/main.sh
         post: $GITHUB_ACTION_PATH/post.sh

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
   using: "composite"
   steps:
     - name: zerotier
-      uses: zerotier/github-action/util/post@add-tags-and-capabilities
+      uses: zerotier/github-action/util/post@main
       env:
         API_URL: ${{ inputs.api_url }}
         AUTH_TOKEN: ${{ inputs.auth_token }}

--- a/main.sh
+++ b/main.sh
@@ -21,10 +21,21 @@ echo "⏁  Authorizing Runner to ZeroTier network"
 MAX_RETRIES=10
 RETRY_COUNT=0
 
+f_tags=""
+f_capabilities=""
+
+if [ -n "$TAGS" ]; then
+    f_tags=$(echo "$TAGS" | awk '{ gsub(/ /, "], [", $0); gsub(/=/, ", ", $0); printf ", \"tags\": [ [%s] ]", $0; }')
+fi
+
+if [ -n "$CAPABILITIES" ]; then
+    f_capabilities=$(echo "$CAPABILITIES" | awk '{ gsub(/ /, ", "); printf ", \"capabilities\": [%s]", $0 }')
+fi
+
 while ! curl -s -X POST \
   -H "Authorization: token $AUTH_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"name":"Zerotier GitHub Member '"${GITHUB_SHA::7}"'", "description": "Member created by '"${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"'", "config":{"authorized":true}}' \
+  -d '{"name":"Zerotier GitHub Member '"${GITHUB_SHA::7}"'", "description": "Member created by '"${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"'", "config":{"authorized":true'"${f_tags}${f_capabilities}"'}}' \
   "$API_URL/network/$NETWORK_ID/member/${member_id}" | grep '"authorized":true'; do
   RETRY_COUNT=$((RETRY_COUNT + 1))
 


### PR DESCRIPTION
Some ZeroTier network deployments make extensive use of tags and capabilities to segregate network access.

This PR introduces a way to specify the tags and capabilities to be attributed to the GitHub action runner upon creation.

(I do not expect the PR to pass automated tests as the tags and capabilities need to be already created on the test network and I could not find any test setup on the project)